### PR TITLE
ignore packaging files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,21 @@
 *~
 *.pyc
 test.py
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg


### PR DESCRIPTION
Now that https://github.com/calvinmetcalf/topojson.py/pull/14 is in, ignore the packaging contents in the repository.