### PR TITLE
python3 compatibility

### DIFF
--- a/geojson/geojson.py
+++ b/geojson/geojson.py
@@ -13,7 +13,7 @@ class Transformer:
     def __init__(self,transform,arcs):
         self.scale = transform['scale']
         self.translate = transform['translate']
-        self.arcs = map(self.convert_arc,arcs)
+        self.arcs = list(map(self.convert_arc,arcs))
     def convert_arc(self,arc):
         out_arc = []
         previous=[0,0]
@@ -23,7 +23,7 @@ class Transformer:
             out_arc.append(self.convert_point(previous))
         return out_arc
     def reversed_arc(self,arc):
-        return map(None,reversed(self.arcs[~arc]))
+        return list(map(None,reversed(self.arcs[~arc])))
     def stitch_arcs(self,arcs):
         line_string = []
         for arc in arcs:
@@ -40,7 +40,7 @@ class Transformer:
                 line_string.extend(line)
         return line_string
     def stich_multi_arcs(self,arcs):
-        return map(self.stitch_arcs,arcs)
+        return list(map(self.stitch_arcs,arcs))
     def convert_point(self,point):
         return [point[0]*self.scale[0]+self.translate[0],point[1]*self.scale[1]+self.translate[1]]
     def feature(self,feature):
@@ -76,7 +76,7 @@ class Transformer:
         geometry['coordinates']=self.convert_point(geometry[coordinates])
         return geometry
     def multi_point(self,geometry):
-        geometry['coordinates']=map(self.convert_point,geometry[coordinates])
+        geometry['coordinates']= list(map(self.convert_point,geometry[coordinates]))
         return  geometry
     def line_string(self,geometry):
         geometry['coordinates']=self.stitch_arcs(geometry['arcs'])
@@ -87,12 +87,12 @@ class Transformer:
         del geometry['arcs']
         return geometry
     def multi_poly(self,geometry):
-        geometry['coordinates']=map(self.stich_multi_arcs,geometry['arcs'])
+        geometry['coordinates']= list(map(self.stich_multi_arcs,geometry['arcs']))
         del geometry['arcs']
         return geometry
     def geometry_collection(self,geometry):
         out = {'type':'FeatureCollection'}
-        out['features']=map(self.feature,geometry['geometries'])
+        out['features']= list(map(self.feature,geometry['geometries']))
         return out
 def from_topo(topo,obj_name):
     if obj_name in topo['objects']:

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,6 @@ setup(
     name="topojson",
     version="0.1.0",
     license="BSD",
-    packages=find_packages()
+    packages=find_packages(),
+    test_suite = 'test.topojson_test'
 )

--- a/test/topojson_test.py
+++ b/test/topojson_test.py
@@ -1,0 +1,37 @@
+import json
+import unittest
+
+from topojson.conversion import convert
+
+class TestTopojson(unittest.TestCase):
+
+    GeoJSON = json.loads("""
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[
+                            [-10, 10],
+                            [ 10, 10],
+                            [ 10, -10],
+                            [-10, -10],
+                            [-10, 10]
+                        ]]
+                    }
+                }
+            ]
+        }
+    """)
+
+    def setUp(self):
+        pass
+
+    def test_topojson(self):
+        tj = convert(self.GeoJSON)
+        self.assertEqual(tj['type'], 'Topology')
+        # with open('/tmp/out.topojson', 'w') as f:
+            # json.dump(tj, f)

--- a/topojson/__init__.py
+++ b/topojson/__init__.py
@@ -1,1 +1,1 @@
-from conversion import convert as topojson
+from .conversion import convert as topojson

--- a/topojson/arcs.py
+++ b/topojson/arcs.py
@@ -1,9 +1,8 @@
-from hashtable import Hashtable
-#import shelve
-#from os import remove
 from hashlib import sha1
-#from tempfile import mkdtemp
-from utils import point_compare
+
+from .hashtable import Hashtable
+from .utils import point_compare
+
 class Arcs:
     def __init__(self,Q):
         self.coincidences = Hashtable(Q * 10)
@@ -39,7 +38,7 @@ class Arcs:
         return out
     def get_hash(self,arc):
         ourhash = sha1()
-        ourhash.update(str(arc))
+        ourhash.update(str(arc).encode('utf8'))
         return ourhash.hexdigest()
     def check(self,arcs):
         a0 = arcs[0]
@@ -56,4 +55,4 @@ class Arcs:
             self.db[self.get_hash(list(reversed(arcs)))]=~index
             self.push(arcs)
             return index
-        
+

--- a/topojson/bounds.py
+++ b/topojson/bounds.py
@@ -1,4 +1,4 @@
-from mytypes import Types
+from .mytypes import Types
 
 def bound(objects):
     class Bounds(Types):

--- a/topojson/clockwise.py
+++ b/topojson/clockwise.py
@@ -3,7 +3,7 @@ class Clock:
         self.area=area
     def clock(self,feature):
         if 'geometries' in feature:
-            feature['geometries'] = map(self.clock_geometry,feature['geometries'])
+            feature['geometries'] = list(map(self.clock_geometry,feature['geometries']))
         elif 'geometry' in feature:
             feature['geometry']=self.clock_geometry(feature['geometry'])
         return feature
@@ -12,12 +12,12 @@ class Clock:
             if geo['type']=='Polygon' or geo['type']=='MultiLineString':
                 geo['coordinates'] = self.clockwise_polygon(geo['coordinates'])
             elif geo['type']=='MultiPolygon':
-                geo['coordinates'] = map(lambda x:self.clockwise_polygon(x),geo['coordinates'])
+                geo['coordinates'] = list(map(lambda x:self.clockwise_polygon(x),geo['coordinates']))
             elif geo['type']=='LineString':
                 geo['coordinates'] = self.clockwise_ring(geo['coordinates'])
         return geo
     def clockwise_polygon(self,rings):
-        return map(lambda x:self.clockwise_ring(x),rings)
+        return list(map(lambda x:self.clockwise_ring(x),rings))
     def clockwise_ring(self,ring):
         if self.area(ring) > 0:
             return list(reversed(ring))

--- a/topojson/conversion.py
+++ b/topojson/conversion.py
@@ -1,15 +1,18 @@
-from topology import topology
 from json import load,dump
+import io
 
-def convert(geojson,topojson,object_name=False, *args, **kwargs):
+from .topology import topology
+
+
+def convert(geojson,topojson=None,object_name=False, *args, **kwargs):
     if isinstance(geojson,dict):
         input_dict = geojson
-    elif isinstance(geojson,str) or isinstance(geojson,unicode):
+    elif isinstance(geojson,str):
         inFile = open(geojson)
         input_dict = load(inFile)
         if not object_name and 'type' in input_dict and hasattr(inFile,'name') and inFile.name.lower().endswith('.geojson'):
             input_dict = {inFile.name[:-8].split('/')[-1]:input_dict}
-    elif isinstance(geojson,file):
+    elif isinstance(geojson, io.TextIOWrapper):
         input_dict=load(geojson)
     if 'type' in input_dict:
         if object_name:
@@ -17,10 +20,10 @@ def convert(geojson,topojson,object_name=False, *args, **kwargs):
         else:
             input_dict = {'name':input_dict}
     output_dict = topology(input_dict, *args, **kwargs)
-    if isinstance(topojson,str) or isinstance(topojson,unicode):
+    if isinstance(topojson,str) or isinstance(topojson, str):
         with open(topojson,'w') as f:
             dump(output_dict,f)
-    elif isinstance(topojson,file):
+    elif isinstance(topojson, io.TextIOWrapper):
         dump(output_dict,topojson)
     else:
         return output_dict

--- a/topojson/hashtable.py
+++ b/topojson/hashtable.py
@@ -1,19 +1,21 @@
 from math import ceil, log
 
 def hasher(size):
-    mask = int(size) - 1;
+    mask = int(size) - 1
+
     def retFunc(point):
-        if type(point)==type([]) and len(point)==2:
+        if type(point)==type([]) and len(point) == 2:
             key = (int(point[0]) + 31 * int(point[1])) | 0
             return (~key if key < 0 else key) & mask
     return retFunc
 
+
 class Hashtable:
     def __init__(self,size):
         self.size = 1 << int(ceil(log(size)/log(2)))
-        self.table = map(lambda x:False,range(0,int(size)))
+        self.table = list(map(lambda x:False,range(0,int(size))))
         self.h = hasher(size)
-        
+
     def peak(self,key):
         matches = self.table[self.h(key)]
         if matches:
@@ -21,6 +23,7 @@ class Hashtable:
                 if equal(match['key'], key):
                     return match['values']
         return None
+
     def get(self,key):
         index = self.h(key)
         if not index:
@@ -35,5 +38,7 @@ class Hashtable:
         values = []
         matches.append({'key': key, 'values': values})
         return values
+
+
 def equal(keyA, keyB):
     return keyA[0] == keyB[0] and keyA[1] == keyB[1]

--- a/topojson/line.py
+++ b/topojson/line.py
@@ -1,5 +1,5 @@
-from arcs import Arcs
-from utils import point_compare,is_point,Strut,mysterious_line_test
+from .arcs import Arcs
+from .utils import point_compare,is_point,Strut,mysterious_line_test
 
 
 class Line:

--- a/topojson/simplify.py
+++ b/topojson/simplify.py
@@ -1,5 +1,5 @@
 #from https://github.com/omarestrella/simplify.py
-from mytypes import Types
+from .mytypes import Types
 
 def getSquareDistance(p1, p2):
     """
@@ -123,16 +123,16 @@ def simplify_object(obj,tolerance):
         def line(self,points):
             return simplify(points,tolerance)
         def polygon(self,coordinates):
-            return map(self.line,coordinates)
+            return list(map(self.line,coordinates))
         def GeometryCollection(self,collection):
-            if 'geometries' in collection:
-                collection['geometries'] = map(self,geometry,collection['geometries'])
+            if collection.has_key('geometries'):
+                collection['geometries'] = list(map(self,geometry,collection['geometries']))
         def LineString(self,lineString):
             lineString['coordinates'] = self.line(lineString['coordinates'])
         def MultiLineString(self,multiLineString):
-            multiLineString['coordinates']=map(self.line,multiLineString['coordinates'])
+            multiLineString['coordinates'] = list(map(self.line,multiLineString['coordinates']))
         def MultiPolygon(self,multiPolygon):
-            multiPolygon['coordinates'] = map(self.polygon,multiPolygon['coordinates'])
+            multiPolygon['coordinates'] = list(map(self.polygon,multiPolygon['coordinates']))
         def Polygon(self,polygon):
             polygon['coordinates']=self.polygon(polygon['coordinates'])
     Simplify(obj)

--- a/topojson/stitchpoles.py
+++ b/topojson/stitchpoles.py
@@ -1,11 +1,11 @@
-from mytypes import Types
+from .mytypes import Types
 
 def stitch (objects, options=False):
     verbose = False;
 
     if type(options)==type({}) and 'verbose' in options:
         verbose = not not options['verbose']
-        
+
     class Stitch(Types):
         def polygon(self,polygon):
             for line in polygon:


### PR DESCRIPTION
Things like map() return iterators instead of lists in Python 3, which caused some problems. This PR converts the result of those calls to lists explicitly, and fixes relative imports.  A simple test case was added, and it passes under python 2.7.10 and Python 3.4.2.