### PR TITLE
point needs coordinates parameter

### DIFF
--- a/topojson/mytypes.py
+++ b/topojson/mytypes.py
@@ -68,7 +68,7 @@ class Types:
             return self.Polygon(geometry)
         elif geometry['type']== 'GeometryCollection':
             return self.GeometryCollection(geometry)
-    def point(self):
+    def point(self,coordinates):
         pass
     def line(self,coordinates):
         for coordinate in coordinates:


### PR DESCRIPTION
otherwise conversion of GeoJSON with single Point features will fail.

```
import topojson
import json

geojson="""
{
  "features": [
    {
      "geometry": {
        "coordinates": [
          6.625,
          47.375
        ],
        "type": "Point"
      },
      "type": "Feature",
      "id": "(6.625, 47.375)",
      "properties": {
        "lat": 6.625,
        "lon": 47.375,
        "tasmin": 2.3124633789,
        "fill": "#f00",
        "tasmax": 6.2972961426,
        "marker-color": "#f00"
      }
    }
  ],
  "type": "FeatureCollection"
}
"""

try :
    topojson.topojson(json.loads(geojson),"/dev/null")
except Exception :
    raise
else :
    print("Successfully converted point")
```

this fails with the following message: TypeError: point() takes exactly 1 argument (2 given)




